### PR TITLE
Fix version of @types/express-session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,12 +152,13 @@
       }
     },
     "@types/express-session": {
-      "version": "1.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.17.3.tgz",
-      "integrity": "sha512-57DnyxiqClXOIjoCgeKCUYfKxBPOlOY/k+l1TPK+7bSwyiPTrS5FIk1Ycql7twk4wO7P5lfOVy6akDGiaMSLfw==",
+      "version": "1.15.16",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.15.16.tgz",
+      "integrity": "sha512-vWQpNt9t/zc4bTX+Ow5powZb9n3NwOM0SYsAJ7PYj5vliB6FA40ye5sW5fZTw8+ekbzJf/sgvtQocf7IryJBJw==",
       "dev": true,
       "requires": {
-        "@types/express": "*"
+        "@types/express": "*",
+        "@types/node": "*"
       }
     },
     "@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/cors": "^2.8.7",
     "@types/dotenv": "^6.1.1",
     "@types/express": "^4.17.0",
-    "@types/express-session": "^1.15.14",
+    "@types/express-session": "^1.15.16",
     "@types/node": "^12.7.1",
     "@types/randomstring": "^1.1.6",
     "@types/redis": "^2.8.13",


### PR DESCRIPTION
- To avoid error TS2694: Namespace 'global.Express' has no exported member 'SessionData'.
- See: https://stackoverflow.com/questions/64845125/namespace-express-has-no-exported-member-sessiondata